### PR TITLE
Update upgrade_web.sh

### DIFF
--- a/upgrade_web.sh
+++ b/upgrade_web.sh
@@ -107,7 +107,7 @@ if [ -e "tengine-$tengine_version.tar.gz" ];then
         echo "Press Ctrl+c to cancel or Press any key to continue..."
         char=`get_char`
         tar xzf tengine-$tengine_version.tar.gz
-        cd tengine-$tengine_version
+        cd tengine
         make clean
         $web_install_dir/sbin/nginx -V &> $$
         tengine_configure_arguments=`cat $$ | grep 'configure arguments:' | awk -F: '{print $2}'`


### PR DESCRIPTION
第110行，删掉“-$tengine_version”。因为2.0.1的官方包解压了tengine后面没有版本。
